### PR TITLE
動的ルーティングのコンテンツの出し分け

### DIFF
--- a/pages/users/_id.vue
+++ b/pages/users/_id.vue
@@ -1,7 +1,17 @@
 <template>
   <div>
     <p>
-      /users/_id.vue
+      User ID: {{userId}}
     </p>
   </div>
 </template>
+
+<script>
+export default {
+  data() {
+    return {
+      userId: this.$route.params.id
+    }
+  },
+}
+</script>


### PR DESCRIPTION
- `this.$route.params.id`でIDをDOM上に表示
→ `_id.vue`ファイルの`_`以降（今回はid）の名前がそのままプロパティになってparamsに代入される。