### PR TITLE
htmlメタの設定

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -4,6 +4,7 @@ module.exports = {
   */
   head: {
     title: 'nuxt-tutorial',
+    titleTemplate: '%s | Nuxt.js tag items viewer',
     meta: [
       { charset: 'utf-8' },
       { name: 'viewport', content: 'width=device-width, initial-scale=1' },

--- a/pages/users/_id.vue
+++ b/pages/users/_id.vue
@@ -25,6 +25,11 @@
 
 <script>
 export default {
+  head() {
+    return {
+      title: this.user.id
+    }
+  },
   async asyncData({ route, app }) {
     const user = await app.$axios.$get(`https://qiita.com/api/v2/users/${route.params.id}`)
     const items = await app.$axios.$get(`https://qiita.com/api/v2/items?query=user:${route.params.id}`)


### PR DESCRIPTION
- メタ情報の書き換え
→ `nuxt.config.js`の`head`から自由に書き換えることができる。

#### 例：共通タイトルの設定

1. `nuxt.config.js`の`head`内に`titleTemplate`を追加
```
head: {
    title: 'nuxt-tutorial',
    titleTemplate: '%s | Nuxt.js tag items viewer',
    meta: [
     ......
    ],
.....
```
`Nuxt.js tag items viewer`が共通部分で`%s`にカスタムされた`title`が入る

2. タイトルをカスタムしたいファイルの`<script>`タグ部分に`head`メソッドを追加（`pages/users/_id.vue`）
```
head() {
    return {
      title: this.user.id
    }
},
```
`asyncData`関数内で宣言した`user`の`id`をタイトルに入れている。