### PR TITLE
vuexストアを各ページに反映

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -22,18 +22,17 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
+
 export default {
-  // async mounted() {
-  //   console.log(
-  //     JSON.stringify(
-  //       await this.$axios.$get('https://qiita.com/api/v2/items?query=tag:nuxt.js'), true, '')
-  //   )
-  // },
-  async asyncData({ app }) {
-    const items = await app.$axios.$get('https://qiita.com/api/v2/items?query=tag:nuxt.js')
-    return {
-      items
+  async asyncData({ store }) {
+    if(store.getters['items'].length) {
+      return
     }
+    await store.dispatch('fetchItems')
+  },
+  computed: {
+    ...mapGetters(['items'])
   },
 }
 </script>

--- a/pages/users/_id.vue
+++ b/pages/users/_id.vue
@@ -24,16 +24,32 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
+
 export default {
   head() {
     return {
       title: this.user.id
     }
   },
-  async asyncData({ route, app }) {
-    const user = await app.$axios.$get(`https://qiita.com/api/v2/users/${route.params.id}`)
-    const items = await app.$axios.$get(`https://qiita.com/api/v2/items?query=user:${route.params.id}`)
-    return { user, items }
+  async asyncData({ route, store, redirect }) {
+    if (store.getters['users'][route.params.id]) {
+      return
+    }
+    try {
+      await store.dispatch('fetchUserInfo', { id: route.params.id })
+    } catch(e) {
+      redirect('/')
+    }
+  },
+  computed: {
+    user() {
+      return this.users[this.$route.params.id]
+    },
+    items() {
+      return this.userItems[this.$route.params.id] || []
+    },
+    ...mapGetters(['users', 'userItems'])
   },
 }
 </script>

--- a/store/index.js
+++ b/store/index.js
@@ -16,7 +16,7 @@ export default () => (new Vuex.Store({
       state.items = items
     },
     setUser(state, { user }) {
-      state.user[user.id] = user
+      state.users[user.id] = user
     },
     setUserItems(state, { user, items }) {
       state.userItems[user.id] = items

--- a/store/index.js
+++ b/store/index.js
@@ -16,7 +16,7 @@ export default () => (new Vuex.Store({
       state.items = items
     },
     setUser(state, { user }) {
-      state.user[user.id] = items
+      state.user[user.id] = user
     },
     setUserItems(state, { user, items }) {
       state.userItems[user.id] = items

--- a/store/index.js
+++ b/store/index.js
@@ -1,0 +1,39 @@
+import Vuex from 'vuex'
+
+export default () => (new Vuex.Store({
+  state: {
+    items: [],
+    users: {},
+    userItems: {},
+  },
+  getters: {
+    items: (state) => state.items,
+    users: (state) => state.users,
+    userItems: (state) => state.userItems,
+  },
+  mutations: {
+    setItems(state, { items }) {
+      state.items = items
+    },
+    setUser(state, { user }) {
+      state.user[user.id] = items
+    },
+    setUserItems(state, { user, items }) {
+      state.userItems[user.id] = items
+    },
+  },
+  actions: {
+    async fetchItems({ commit }) {
+      const items = await this.$axios.$get('https://qiita.com/api/v2/items?query=tag:nuxt.js')
+      commit('setItems', { items })
+    },
+    async fetchUserInfo({ commit }, { id }) {
+      const [user, items] = await Promise.all([
+        this.$axios.$get(`https://qiita.com/api/v2/users/${id}`),
+        this.$axios.$get(`https://qiita.com/api/v2/items?query=user:${id}`)
+      ])
+      commit('setUser', { user })
+      commit('setUserItems', { user, items })
+    },
+  },
+}))


### PR DESCRIPTION
### コンポーネント側でやること

- アクションを実行させる（`dispatch`メソッド）

`await store.dispatch('fetchItems')`（`pages/index.vue`）

`await store.dispatch('fetchUserInfo', { id: route.params.id })`（`pages/users/_id.vue`）

- ステートに保存されているデータを取得して表示（`computed`の`mapGetters`メソッド）

```
computed: {
    ...mapGetters(['items'])
},

```
↑ （`pages/index.vue`）
```
computed: {
    user() {
      return this.users[this.$route.params.id]
    },
    items() {
      return this.userItems[this.$route.params.id] || []
    },
    ...mapGetters(['users', 'userItems'])
},
```
↑ （`pages/users/_id.vue`）